### PR TITLE
Support for Multiple Active Directory Instances

### DIFF
--- a/etcmakemunki/config
+++ b/etcmakemunki/config
@@ -5,8 +5,9 @@ codehome = /home/someplace/mtm
 baseurl = https://munkibusiness.mydomain.edu
 fullrepopath = /var/www/repos
 urlrepobase = /repos
-mkpackagedir = /home/makemunki
-mkpackagesrc = /home/makemunki/munkiconfig-pack
+mkpackagedir = /home/makemunki/MTM/home
+mkpackagesrc = /home/makemunki/MTM/home/munkiconfig-pack
+mtmreconfigdir = /home/makemunki/MTM/MTM.reconfigure
 timezone = America/Chicago
 
 ; This section defines certificate authority configs
@@ -28,16 +29,21 @@ dbpass = munkipass
 backupdir = /var/storage/backupdir
 
 [portal]
+admingroup = SOMEadminGroup
 session_lifetime = 86400
 maximum_window = 20160 ; in minutes = 14 days
 
 [apache]
 per_repo_config = /etc/apache/conf/munki-conf-per-group
+davbase = /some/path/to/repos
+restart = sudo /sbin/service httpd reload
 
 [ldap]
-ldapuri = "ldaps://ad.uillinois.edu/"
-username = "munkiaccountwithprivilegesofsomekind@ad.uillinois.edu"
-password = "secret" ; see mtm/change_ldap_pass.php to change this password.
-basedn = "DC=ad,DC=uillinois,DC=edu"
-dnattribute = sAMAccountName
+name[] = UIUC
+
+UIUC[ldapuri] = "ldaps://ad.uillinois.edu/"
+UIUC[username] = "munkiaccountwithprivilegesofsomekind@ad.uillinois.edu"
+UIUC[password] = "secret" ; see mtm/change_ldap_pass.php to change this password.
+UIUC[basedn] = "DC=ad,DC=uillinois,DC=edu"
+UIUC[dnattribute] = sAMAccountName
 

--- a/etcmakemunki/readconfig.php
+++ b/etcmakemunki/readconfig.php
@@ -3,7 +3,7 @@
 class ReadConfig {
 
     private $vars;
-    
+
     public function __construct($filename) {
         if(is_array($filename)) {
             $this->vars = $filename;
@@ -25,7 +25,13 @@ class ReadConfig {
     public function __get($key) {
         if(isset($this->vars[$key])) {
             if(is_array($this->vars[$key])) {
-                return new ReadConfig($this->vars[$key]);
+                $checks = array_keys($this->vars[$key]);
+                foreach($checks as $check) {
+                    if(!is_numeric($check)) {
+                        return new ReadConfig($this->vars[$key]);
+                    }
+                }
+                return $this->vars[$key];
             } else {
                 return $this->vars[$key];
             }

--- a/home/munkiconfig-pack/Scripts/preflight
+++ b/home/munkiconfig-pack/Scripts/preflight
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+FILELIST='00_MTM.reconfigure 00_MTM.reconfigure-core 00_MTM.run_directory 00_MTM.reconfigure'
+for FILE in $FILELIST;do
+  if [ -f $FILE ]; then
+     rm $FILE
+  fi
+done
+
+if [ -L /usr/local/munki/preflight ]; then
+   rm /usr/local/munki/preflight
+fi

--- a/mtm/bootstrap-repo.php
+++ b/mtm/bootstrap-repo.php
@@ -1,8 +1,8 @@
 #!/usr/bin/env php
 <?php
 
-if(!isset($argv[1])) {
-    throw new exception("You need to specify the samaccount name on the command line.");
+if(!isset($argv[1],$argv[2])) {
+    throw new exception("You need to specify the samaccount name and the LDAP name on the command line.");
 }
 
 require_once "/etc/makemunki/readconfig.php";
@@ -17,14 +17,16 @@ $mtm = new MTM;
 $ldg = new LdapGroups;
 $sa = new Shib_Auth;
 
+$names = $ldg->ldap_names();
+
 try {
-    $res = $ldg->group_info_from_samaccountname($argv[1]);
+    $res = $ldg->group_info_from_samaccountname($argv[1],$argv[2]);
     if($res['count']!=1) {
-        throw new exception("AD/LDAP group not found.  Try a different samaccount name");
+        throw new exception("AD/LDAP group not found.  Try a different samaccount name.");
     }
     $adgroup = $res[0]['distinguishedname'][0];
     print "Adding Master Group: ".$adgroup."\n";
-    $shibgroup = $sa->shib_group_from_ad($adgroup);
+    $shibgroup = $sa->shib_group_from_ad($adgroup,$argv[2]);
     print "Shib group: ".$shibgroup."\n";
 } catch (exception $e) {
     print "Error: ".$e->getMessage()."\n";

--- a/mtm/ldapgroups.php
+++ b/mtm/ldapgroups.php
@@ -4,27 +4,35 @@ include_once '/etc/makemunki/readconfig.php';
 
 class LdapGroups  {
 
-    private $gconf;
-    private $ldapconn;
+    static private $gconf;
+    static private $ldapconn;
+    static private $ldapnames;
 
     public function __construct() {
+        if(isset(LdapGroups::$gconf)) {
+            return;
+        }
         $gconf = new ReadConfig('/etc/makemunki/config');
         set_include_path(get_include_path() . ':'.$gconf->main->codehome.'/MunkiCert');
-        $this->gconf = $gconf;
+        LdapGroups::$gconf = $gconf;
         include "pass_service.php";
 
         $sitekey = file_get_contents("/etc/makemunki/sitekey");
-        $ps = new Pass_Service($sitekey);
-        if(!isset($gconf->ldap->password, $gconf->ldap->username, $gconf->ldap->ldapuri, $gconf->ldap->basedn)) {
-            throw new exception("You must set ldap ldapuri, basedn, username, and password in config file.");
-        }
-        $this->ldapconn = ldap_connect($gconf->ldap->ldapuri);
-        if(!isset($this->ldapconn)) {
-            throw new exception("Can't connect to ldap server.");
-        }
-        $bind = ldap_bind($this->ldapconn,$gconf->ldap->username,$ps->pass_from_cipher($gconf->ldap->password));
-        if(!isset($bind)) { 
-            throw new exception("Can't bind to LDAP server.");
+        LdapGroups::$ldapconn = [];
+        LdapGroups::$ldapnames = $gconf->ldap->name;
+        foreach(LdapGroups::$ldapnames as $name) {
+            $ps = new Pass_Service($sitekey);
+            if(!isset($gconf->ldap->$name->password, $gconf->ldap->$name->username, $gconf->ldap->$name->ldapuri, $gconf->ldap->$name->basedn)) {
+                throw new exception("You must set ldap ldapuri, basedn, username, and password for $name in config file.");
+            }
+            LdapGroups::$ldapconn[$name] = ldap_connect($gconf->ldap->$name->ldapuri);
+            if(!isset(LdapGroups::$ldapconn[$name])) {
+                throw new exception("Can't connect to ldap server.");
+            }
+            $bind = ldap_bind(LdapGroups::$ldapconn[$name],$gconf->ldap->$name->username,$ps->pass_from_cipher($gconf->ldap->$name->password));
+            if(!isset($bind)) { 
+                throw new exception("Can't bind to LDAP server.");
+            }
         }
     }
 
@@ -38,15 +46,26 @@ class LdapGroups  {
         return $in_string;
     }
 
-    public function group_info_from_samaccountname($in_group) {
-        $filter = "(".$this->gconf->ldap->dnattribute."=".$this->my_ldap_escape($in_group).")";
+    public function group_info_from_samaccountname($in_group,$in_name) {
+        if(!isset(LdapGroups::$gconf->ldap->$in_name,LdapGroups::$ldapconn[$in_name])) {
+            throw new exception("No config for ldap name $in_name");
+        }
+        $filter = "(".LdapGroups::$gconf->ldap->$in_name->dnattribute."=".$this->my_ldap_escape($in_group).")";
         $retarray = array("member","sAMAccountName","distinguishedName");
-        $res = ldap_search($this->ldapconn,$this->gconf->ldap->basedn,$filter,$retarray);
-        $info = ldap_get_entries($this->ldapconn,$res);
+        $res = ldap_search(LdapGroups::$ldapconn[$in_name],LdapGroups::$gconf->ldap->$in_name->basedn,$filter,$retarray);
+        $info = ldap_get_entries(LdapGroups::$ldapconn[$in_name],$res);
         return $info;
     }
 
+    public function ldap_names() {
+        return LdapGroups::$ldapnames;
+    }
+
+    public function ldap_config($in_name) {
+        if(isset(LdapGroups::$gconf->ldap->$in_name)) {
+            return LdapGroups::$gconf->ldap->$in_name;
+        }
+        throw new exception("Ldap connection name $in_name not found");
+    }
+
 }
-
-
-    

--- a/mtm/myapi.php
+++ b/mtm/myapi.php
@@ -540,10 +540,11 @@ class MyAPI extends API
                 try {
                     $shib_auth = new Shib_Auth;
                     if(!isset($invars->ad_path) ||
-                    !isset($invars->id)) {
+                    !isset($invars->id) ||
+                    !isset($invars->ldapname)) {
                         return ['status'=>['error'=>'1','text'=>'Not enough parameters to add shib group']];
                     }
-                    $shib_auth->add_shibgroup_to_usergroup($invars->ad_path,$invars->id,$_SESSION['user']);
+                    $shib_auth->add_shibgroup_to_usergroup($invars->ad_path,$invars->id,$invars->ldapname,$_SESSION['user']);
                     return ['status'=>['error'=>0,'text'=>'OK']];
                 }
                 catch (exception $e) {
@@ -652,16 +653,20 @@ class MyAPI extends API
                 if(!(isset($this->args[0]))) {
                     return ['status'=>['error'=>'1','text'=>'No group specified']];
                 }
-
                 try {
-                    $res = $shib_auth->get_ad_group_dn($this->args[0]);
-                    $sg = $shib_auth->shib_group_from_ad($res);
+                    $res = $shib_auth->get_ad_group_dn($this->args[1],$this->args[0]);
+                    $sg = $shib_auth->shib_group_from_ad($res,$this->args[0]);
                     return ['distinguishedname'=>$res,'shib_group'=>$sg];
                 }
                 catch (exception $e) {
                     return ['status'=>['error'=>1,'text'=>$e->getMessage()]];
                 }
                 break;
+
+            case 'ldapnames':
+                $lg = new LdapGroups;
+                $names = $lg->ldap_names();
+                return $names;
 
             default:
                 return ['status'=>['error'=>1,'text'=>'I do not understand the request']];

--- a/mtm/shib_auth.php
+++ b/mtm/shib_auth.php
@@ -209,17 +209,22 @@ class Shib_Auth {
         $adsize = count($adparts);
         $parts = explode(',',$in_adgroup);
         $size = count($parts);
-        $shib_group=$ldconfig->shib_group_base;
+        if($ldconfig->shib_full_path === 'Y') {
+            $shib_group=$ldconfig->shib_group_base;
         
-        for($i=1;$i <= $adsize; $i++) {
-            if($parts[$size-$i] !== $adparts[$adsize-$i]) {
-                throw new exception ("I can't figure out the group '$in_adgroup'.");
+            for($i=1;$i <= $adsize; $i++) {
+                if($parts[$size-$i] !== $adparts[$adsize-$i]) {
+                    throw new exception ("I can't figure out the group '$in_adgroup'.");
+                }
             }
-        }
 
-        for ($i=$size-$adsize-1;$i>=0;$i--) {
-            $subsections = explode("=",$parts[$i]);
-            $shib_group .= ':'.strtolower($subsections[1]);
+            for ($i=$size-$adsize-1;$i>=0;$i--) {
+                $subsections = explode("=",$parts[$i]);
+                $shib_group .= ':'.strtolower($subsections[1]);
+            }
+        } else {
+            $subsections = explode('=',$parts[0]);
+            $shib_group = str_replace(" ","_",$subsections[1]);
         }
         return $shib_group;
     }

--- a/mtm/shib_auth.php
+++ b/mtm/shib_auth.php
@@ -27,7 +27,7 @@ class Shib_Auth {
     }
 
 // adds a Shib group to a UserGroup
-   public function add_shibgroup_to_usergroup($in_shibgroup_adpath, $in_usergroup_ID, $in_user = 'root') {
+    public function add_shibgroup_to_usergroup($in_shibgroup_adpath, $in_usergroup_ID, $in_ldap_name, $in_user = 'root') {
        $mtm = new MTM;
        // Several steps.
        // Determine if user has permission in usergroup.
@@ -52,7 +52,7 @@ class Shib_Auth {
        if(count($shgs) != 1) {
            $new_shg = new T_ShibGroup;
            $new_shg->ad_path = $norm_ad_path;
-           $new_shg->shib_path = $this->shib_group_from_ad($norm_ad_path);
+           $new_shg->shib_path = $this->shib_group_from_ad($norm_ad_path,$in_ldap_name);
            $new_shg->save();
            $shg = $new_shg;
        } else {
@@ -201,19 +201,23 @@ class Shib_Auth {
            
 
 // 
-   public function shib_group_from_ad($in_adgroup) {
+   public function shib_group_from_ad($in_adgroup,$in_ldapname) {
+        $lg = new LdapGroups;
+        
+        $ldconfig= $lg->ldap_config($in_ldapname);
+        $adparts = explode(',',$ldconfig->basedn);
+        $adsize = count($adparts);
         $parts = explode(',',$in_adgroup);
         $size = count($parts);
-        // Unhardcode these items.
-        $shib_group='urn:mace:uiuc.edu';
-        // unhardcode these items.
-        if($parts[$size-1] !== 'DC=edu'
-        || $parts[$size-2] !== 'DC=uillinois'
-        || $parts[$size-3] !== 'DC=ad') {
-            throw new exception ("I can't figure out the group '$in_adgroup'.");
+        $shib_group=$ldconfig->shib_group_base;
+        
+        for($i=1;$i <= $adsize; $i++) {
+            if($parts[$size-$i] !== $adparts[$adsize-$i]) {
+                throw new exception ("I can't figure out the group '$in_adgroup'.");
+            }
         }
 
-        for ($i=$size-4;$i>=0;$i--) {
+        for ($i=$size-$adsize-1;$i>=0;$i--) {
             $subsections = explode("=",$parts[$i]);
             $shib_group .= ':'.strtolower($subsections[1]);
         }
@@ -230,9 +234,9 @@ class Shib_Auth {
         return 0;
     }
 
-    public function get_ad_group_dn($in_group) {
+    public function get_ad_group_dn($in_group,$in_ldapname) {
         $lg = new LdapGroups;
-        $ress = $lg->group_info_from_samaccountname($in_group);
+        $ress = $lg->group_info_from_samaccountname($in_group,$in_ldapname);
 
         if($ress['count']!=1) {
             throw new exception("get_ad_group_dn: group not found or multiple groups found.");

--- a/mtm/test-ldap-lookup.php
+++ b/mtm/test-ldap-lookup.php
@@ -14,10 +14,10 @@ require "ldapgroups.php";
 $ldg = new LdapGroups;
 
 try {
-    $res = $ldg->group_info_from_samaccountname($argv[1]);
+    $res = $ldg->group_info_from_samaccountname($argv[1],$argv[2]);
     if($res['count']==1) {
         print "Found Entry: ".$res[0]['distinguishedname'][0]."\n";
     }
 } catch (exception $e) {
-    print "Error: ".$e->getMessage();
+    print "Error: ".$e->getMessage()."\n";
 }

--- a/portal/GroupService.js
+++ b/portal/GroupService.js
@@ -90,11 +90,16 @@ ComputerService.factory("GroupPerms",function($resource,myErrorHandler) {
 			 interceptor: { responseError: myErrorHandler.doit}},
 
 	'adlookup': {method:'GET',
-			 url:"/api/v1/adgroups/samaccountname/:key",
+			 url:"/api/v1/adgroups/samaccountname/:ldapname/:key",
 			 isArray:false,
 			 transformResponse: function(data) {return myErrorHandler.format(data)},
 			 interceptor: { responseError: myErrorHandler.doit}},
 
+        'ldapname': {method:'GET',
+			 url:"/api/v1/adgroups/ldapnames",
+			 isArray:true,
+			 transformResponse: function(data) {return myErrorHandler.format(data)},
+			 interceptor: { responseError: myErrorHandler.doit}},
 
     });
 
@@ -467,8 +472,12 @@ app.controller("UserGroupEditController",function($scope,$routeParams,GroupPerms
 							      key:$routeParams.key},
 							     function(data){
 								 $scope.processshibgroupdata(data);});
+
+			      GroupPerms.ldapname({},function(data) {
+				  $scope.processldapnamedata(data);});
+
 			  });
-    
+
     var checklastresults = function() {
 	var theresults = GroupPerms.getlastresults();
 	if(angular.isDefined(theresults.status)) {
@@ -533,6 +542,19 @@ app.controller("UserGroupEditController",function($scope,$routeParams,GroupPerms
 	    $scope.shibgroups = data;
 	}
 	$scope.displayshibgroups = [] . concat ($scope.shibgroups);
+    }
+
+    $scope.processldapnamedata = function(data) {
+	console.log("ldapnames");
+	console.log(data);
+	if(data.length < 1) {
+	    $scope.goodldapnames = 0;
+	    $scope.ldapnames = [];
+	} else {
+	    $scope.goodldapnames = 1;
+	    $scope.ldapnames = data;
+	    $scope.form_ldapname = data[0];
+	}
     }
 
     $scope.setedit_repository = function(activeID) {
@@ -616,7 +638,7 @@ app.controller("UserGroupEditController",function($scope,$routeParams,GroupPerms
 	if(level == 2) {
 	    $scope.lookup_adgrouppath = "";
 	    $scope.lookup_shibgroup = "";
-	    GroupPerms.adlookup({key:$scope.newshibadgroup},
+	    GroupPerms.adlookup({key:$scope.newshibadgroup,ldapname:$scope.form_ldapname},
 				function(data) {
 				    if(angular.isDefined(data.distinguishedname)) {
 					$scope.goodadlookup = true;
@@ -626,7 +648,7 @@ app.controller("UserGroupEditController",function($scope,$routeParams,GroupPerms
 				});
 	}
 	if(level == 3) {
-	    GroupPerms.addusershibgroup({id:$routeParams.key,ad_path:$scope.lookup_adgrouppath},
+	    GroupPerms.addusershibgroup({id:$routeParams.key,ad_path:$scope.lookup_adgrouppath,ldapname:$scope.form_ldapname},
 					function(data) {
 					    if(angular.isDefined(data.status)) {
 						GroupPerms.setlastresults(data);

--- a/portal/computeredit.html
+++ b/portal/computeredit.html
@@ -33,14 +33,15 @@
     <div class="form-group">
         <label class="col-sm-2 control-label">Name*</label>
         <div class="col-sm-5">
-            <input class="form-control" type="text" ng-model="form_name" ng-required="1" placeholder="Computer's unique name. Typically hostname or serial number."/>
+            <input class="form-control" type="text" ng-model="form_name" ng-required="1" placeholder="Computer's unique name. Typically hostname or serial number." ng-pattern="/^[a-zA-Z0-9\- ]*$/" />
+            <span class="help-block">No special characters allowed except for hyphens.</span>
         </div>
     </div>
 
     <div class="form-group">
         <label class="col-sm-2 control-label">Serial Number*</label>
         <div class="col-sm-5">
-            <input class="form-control" type="text" ng-model="form_identifier" ng-required="1" placeholder="Computer's serial number. Must be CAPITALIZED."/>
+            <input class="form-control" type="text" ng-model="form_identifier" ng-required="1" placeholder="Computer's serial number. Must be CAPITALIZED." ng-disabled="showedit" />
         </div>
     </div>
 

--- a/portal/usergroupedit.html
+++ b/portal/usergroupedit.html
@@ -118,6 +118,8 @@
     </div>
     <input class="btn btn-primary" type="submit" ng-click="add_shibgroup(1)" value="Add Shib Group" />
     <div class="well" ng-show="showshibadd">
+        <p>AD name</p>
+        <select class="form-control" ng-model="form_ldapname" ng-options="ldapname as ldapname for ldapname in ldapnames track by ldapname"></select>
         <p>AD Group Name (Short name, like 'munki admins'):</p>
             <input type="text" name="shibadgroup" ng-model="newshibadgroup" length="160" />
             <input type="submit" value="Look up AD Group" ng-click="add_shibgroup(2)" />

--- a/portal/usergroupedit.html
+++ b/portal/usergroupedit.html
@@ -146,7 +146,7 @@
             </tbody>
         </table>
         <dir-pagination-controls boundary-links="true" template-url="components/dirPagination.tpl.html"></dir-pagination-controls>
-        <div ng-show="!showshibdelete"><input class="btn btn-primary" type="submit" ng-click="enableshibdelete(1)" value="Enable Deletes"/></div><div ng-show="showshibdelete"><input class="btn btn-primary" type="submit" ng-click="enableshibdelete(0)" value="Cancel Deletes"/></div>
+        <div ng-show="!showshibdelete"><input class="btn btn-primary" type="submit" ng-click="enableshibdelete(1)" value="Enable Deletes"/></div><div ng-show="showshibdelete"><input class="btn btn-primary" type="submit" ng-click="enableshibdelete(0)" value="Disable Deletes"/></div>
     </div>
     
 </div>


### PR DESCRIPTION
- UIC domain functionality added
   - Domain selection dropdown added to Associated Shibboleth Groups section of user group page

- Prevent the modification of the serial number field
  - Prevents issue that some users encountered when they changed serial numbers after the machine certificate had already been issued

- Prevent special characters in computer name field when editing individual computer records
   - Prevents issue that some users encountered when they had illegal special characters in the computer name field and tried to use the ‘Force Rename’ functionality. This would halt the onboarding process.

- Cosmetic change of ‘Cancel Deletes’ button to ‘Disable Deletes’ on the user group edit page to parallel the ‘Enables Deletes’ button