### PR TITLE
Fix bug for re-onboarding machines

### DIFF
--- a/home/munkiconfig-pack/Scripts/postflight
+++ b/home/munkiconfig-pack/Scripts/postflight
@@ -25,8 +25,10 @@ else
     if [ -x /usr/local/munki/preflight ]; then
         mv /usr/local/munki/preflight $PREFLIGHTD/01_historic_preflight
     fi
-    ln -s /usr/local/munki/00_MTM.run_directory /usr/local/munki/preflight
 fi
+
+# Create the preflight symlink
+ln -sfn /usr/local/munki/00_MTM.run_directory /usr/local/munki/preflight
 
 # Second, get the reconfigure piece working.  Figure out what's installed.
 if [ ! -d $PREABORTD ]; then


### PR DESCRIPTION
Fixes bug that affects re-onboarding for machines that remain a symlink and never have /usr/local/munki/preflight replaced with a file (such as when munkireport-php v4 and earlier is installed).